### PR TITLE
修改了SPI发送接收的BUG，增加了STM32移植的接口。

### DIFF
--- a/inc/mfrc522.h
+++ b/inc/mfrc522.h
@@ -12,7 +12,7 @@
 
 #include <rtthread.h>
 #include <rtdevice.h>
-#include <drv_gpio.h>
+#include <drv_common.h>
 
 #ifndef MFRC522_SPI_DEVICE_NAME
 #define MFRC522_SPI_DEVICE_NAME "spi10"

--- a/port/mfrc522_rtt_stm32_port.c
+++ b/port/mfrc522_rtt_stm32_port.c
@@ -1,0 +1,25 @@
+#include "mfrc522.h"
+#include <drv_spi.h>
+
+static int rt_hw_spi_rc522_init()
+{
+    rt_err_t res = RT_EOK;
+    //此处的 GPIOA 和 GPIO_PIN_4 需要根据实际使用的 NSS 引脚编号配置。
+    res = rt_hw_spi_device_attach(MFRC522_SPI_BUS_NAME, MFRC522_SPI_DEVICE_NAME, GPIOA, GPIO_PIN_4);
+    if (res != RT_EOK)
+    {
+        rt_kprintf("[RC522] Failed to attach device %s\n", MFRC522_SPI_DEVICE_NAME);
+        return res;
+    }
+    struct rt_spi_device *spi_dev = (struct rt_spi_device *)rt_device_find(MFRC522_SPI_DEVICE_NAME);
+    // Set device SPI Mode
+    struct rt_spi_configuration cfg = {0};
+    cfg.data_width = 8;
+    cfg.mode = RT_SPI_MASTER | RT_SPI_MODE_0 | RT_SPI_MSB | RT_SPI_NO_CS;
+    cfg.max_hz = MFRC522_SPICLOCK;
+    rt_spi_configure(spi_dev, &cfg);
+
+    return RT_EOK;
+}
+/* 导出到自动初始化 */
+INIT_COMPONENT_EXPORT(rt_hw_spi_rc522_init);


### PR DESCRIPTION
我一共修改了好几处，
`MFRC522()` 函数里增加 `RT_ASSERT(spi_dev_rc522)` 是为了避免出现 HardFault，因为如果系统之前挂载 MFRC522_SPI_DEVICE_NAME 设备失败的话，此时调用 `rt_device_find()` 会返回 NULL，于是 spi_dev_rc522 就为 NULL，这样之后进行读写 spi_dev_rc522 时就会触发 HardFault，我自己最开始就碰见过这种问题，找起来还挺麻烦的。

第二处是添加了我自己配置成功的移植文件，硬件平台为 STM32F103VET6，软件包原本的那个移植文件用不了，我看论坛里也有很多朋友说移植的问题，此处就加上了我自己的移植文件。

第三处就比较关键了，涉及到SPI通信数据读不出来的问题。RT-Thread 的 SPI 设备框架提供了 `rt_spi_send()`, `rt_spi_recv()`,  `rt_spi_send_then_recv()` 这三个函数，但是这三个函数在官方文档里有说明：
> 开始发送或接收数据时片选选中，函数返回时释放片选。

而在本软件包里是手动控制片选信号为低电平或高电平的，如下述代码：
```C
/**
 * Reads a byte from the specified register in the MFRC522 chip.
 * The interface is described in the datasheet section 8.1.2.
 */
byte PCD_ReadReg_Byte(enum PCD_Register reg)
{
	byte value = 0;
	rt_pin_write(_chipSelectPin, PIN_LOW);			// Select slave
	byte address = (byte)(0x80 | reg);			// MSB == 1 is for reading. LSB is not used in address. Datasheet section 8.1.2.3.
	rt_spi_send(spi_dev_rc522, &address, 1);
	rt_spi_recv(spi_dev_rc522, &value, 1);	// Read the value back. Send 0 to stop reading.
	rt_pin_write(_chipSelectPin, PIN_HIGH);			// Release slave again
	return value;
} // End PCD_ReadReg_Byte()
```
这样就会出现这种情况，先手动拉低片选信号，后面调用 `rt_spi_send()` ，RTT 再次拉低片选信号，函数返回时拉高片选信号；调用 `rt_pin_recv()` 时，RTT 又一次拉低片选信号，函数返回时拉高片选信号。
注意这中间有一次释放了片选信号，这会导致 SPI 通信失败，读不出数据。

`PCD_ReadReg_Byte(VersionReg)` 的具体时序如下图：

![image](https://user-images.githubusercontent.com/45490946/98931766-68f18180-2519-11eb-819a-892b9737a9d6.png)

因此我参考官方手册，写了三个发送接收数据时不获取(take)片选信号，发送接收完成之后不释放(release)片选信号的函数，片选信号的操作完全手动操作。并用宏对当前软件包进行了兼容。
